### PR TITLE
fix: use /api/fungible-faucet to disambiguate dapp backends

### DIFF
--- a/api/deploy.js
+++ b/api/deploy.js
@@ -53,8 +53,8 @@ export default async function deployApi(
     // everyone has access to the same Zoe.
     zoe,
 
-    // The http request handler.
-    // TODO: add more explanation
+    // The http service allows registered handlers that are executed as part of
+    // the ag-solo web server.
     http,
 
     // The board is an on-chain object that is used to make private
@@ -128,7 +128,7 @@ export default async function deployApi(
       board,
       invitationIssuer,
     });
-    await E(http).registerAPIHandler(handler);
+    await E(http).registerURLHandler(handler, '/api/fungible-faucet');
   };
 
   await installHandler();

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,8 @@
     "build": "parcel build public/index.html",
     "lint-check": "eslint '**/*.{js,jsx}'",
     "lint-fix": "eslint --fix '**/*.{js,jsx}'",
-    "start": "parcel serve --host=127.0.0.1 --port=3000 public/index.html"
+    "start": "parcel serve --host=127.0.0.1 --port=3000 public/index.html",
+    "test": "exit 0"
   },
   "browserslist": {
     "production": [

--- a/ui/public/conf/defaults.js
+++ b/ui/public/conf/defaults.js
@@ -1,0 +1,14 @@
+// GENERATED FROM /Users/michael/agoric/dapp-fungible-faucet/api/deploy.js
+export default {
+  "INSTANCE_BOARD_ID": "500716545",
+  "INSTALLATION_BOARD_ID": "1456154132",
+  "INVITE_BRAND_BOARD_ID": "1667979430",
+  "brandBoardIds": {
+    "Token": "815824725"
+  },
+  "issuerBoardIds": {
+    "Token": "262188032"
+  },
+  "BRIDGE_URL": "http://127.0.0.1:8000",
+  "API_URL": "http://127.0.0.1:8000"
+};

--- a/ui/public/conf/installationConstants.js
+++ b/ui/public/conf/installationConstants.js
@@ -1,0 +1,5 @@
+// GENERATED FROM /Users/michael/agoric/dapp-fungible-faucet/contract/deploy.js
+export default {
+  "CONTRACT_NAME": "fungibleFaucet",
+  "INSTALLATION_BOARD_ID": "1456154132"
+};

--- a/ui/public/src/connect.js
+++ b/ui/public/src/connect.js
@@ -23,27 +23,29 @@ $debug.addEventListener('change', debugChange);
 debugChange();
 
 /**
- * @param {string} id
+ * @param {string} endpointPath
  * @param {(obj: { type: string, data: any }) => void} recv
  * @param {string} [query='']
  */
-export const connect = (id, recv, query = '') => {
+export const connect = (endpointPath, recv, query = '') => {
+  const statusId = endpointPath === 'wallet' ? 'wallet-status' : `api-status`;
   const $status = /** @type {HTMLSpanElement} */ (document.getElementById(
-    `${id}-status`,
+    statusId,
   ));
   $status.innerHTML = 'Connecting...';
 
-  const endpoint = id === 'wallet' ? `/private/wallet-bridge${query}` : '/api';
+  const endpoint =
+    endpointPath === 'wallet' ? `/private/wallet-bridge${query}` : endpointPath;
 
   /**
    * @param {{ type: string, data: any}} obj
    */
   const send = (obj) => {
     const $m = document.createElement('div');
-    $m.className = `message send ${id}`;
-    $m.innerText = `${id}> ${JSON.stringify(obj)}`;
+    $m.className = `message send ${endpointPath}`;
+    $m.innerText = `${endpointPath}> ${JSON.stringify(obj)}`;
     $messages.appendChild($m);
-    console.log(`${id}>`, obj);
+    console.log(`${endpointPath}>`, obj);
     return rpc(obj, endpoint);
   };
 
@@ -59,7 +61,7 @@ export const connect = (id, recv, query = '') => {
     resolve = res;
     reject = rej;
   });
-  const activator = id === 'wallet' ? startBridge : startApi;
+  const activator = endpointPath === 'wallet' ? startBridge : startApi;
   activator(
     {
       onConnect() {
@@ -74,10 +76,10 @@ export const connect = (id, recv, query = '') => {
           return;
         }
         const $m = document.createElement('div');
-        $m.className = `message receive ${id}`;
-        $m.innerText = `${id}< ${JSON.stringify(obj)}`;
+        $m.className = `message receive ${endpointPath}`;
+        $m.innerText = `${endpointPath}< ${JSON.stringify(obj)}`;
         $messages.appendChild($m);
-        console.log(`${id}<`, obj);
+        console.log(`${endpointPath}<`, obj);
         recv(obj);
       },
       onDisconnect() {

--- a/ui/public/src/main.js
+++ b/ui/public/src/main.js
@@ -97,7 +97,7 @@ export default async function main() {
     return walletSend;
   });
 
-  await connect('api', apiRecv).then((apiSend) => {
+  await connect('/api/fungible-faucet', apiRecv).then((apiSend) => {
     $mintFungible.removeAttribute('disabled');
     $mintFungible.addEventListener('click', () => {
       const offer = {


### PR DESCRIPTION
This paves the way for running two different dapps at the same time.

Just use a different API suffix on the other dapp, and ensure that the UI server starts at a different port than 3000, and you can run all the deploy scripts in both dapps to install both of them at once.
