### PR TITLE
Prevent the wallet from alerting upon offer result

### DIFF
--- a/ui/public/src/main.js
+++ b/ui/public/src/main.js
@@ -164,6 +164,9 @@ export default async function main() {
             },
           },
         },
+
+        // Tell the wallet that we're handling the offer result.
+        dappContext: true,
       };
       apiSend({
         type: 'fungibleFaucet/sendInvitation',


### PR DESCRIPTION
Silence the wallet's offer result alert box by supplying `dappContext`.
