### PR TITLE
chore: produce an error in the contract to replicate the user experience

### DIFF
--- a/contract/src/contract.js
+++ b/contract/src/contract.js
@@ -1,5 +1,6 @@
 // @ts-check
 import '@agoric/zoe/exported';
+import { assert, details } from '@agoric/assert';
 
 /**
  * This is a very simple contract that creates a new issuer and mints payments
@@ -26,15 +27,9 @@ const start = async (zcf) => {
   // can be accessed synchronously.
   const { amountMath, issuer } = zcfMint.getIssuerRecord();
 
-  const mintPayment = (seat) => {
+  const mintPayment = () => {
     const amount = amountMath.make(1000);
-    // Synchronously mint and allocate amount to seat.
-    zcfMint.mintGains({ Token: amount }, seat);
-    // Exit the seat so that the user gets a payout.
-    seat.exit();
-    // Since the user is getting the payout through Zoe, we can
-    // return anything here. Let's return some helpful instructions.
-    return 'Offer completed. You should receive a payment from Zoe';
+    assert(false, details`amount was ${amount}`);
   };
 
   const creatorFacet = {


### PR DESCRIPTION
This PR allows us to experience how a developer sees errors in their contract. The offerHandler has an assert that fails with the details: `amount was ${amount}`.  Currently all the developer would see in the `agoric start` terminal is:

<img width="719" alt="Screen Shot 2020-11-18 at 4 25 13 PM" src="https://user-images.githubusercontent.com/2441069/99604696-f2da9800-29ba-11eb-8948-1fac86ee7574.png">

# To reproduce:
1. use the `hackathon-2020-11` branch of `agoric-sdk`
2. `yarn install` and `yarn build` in agoric-sdk
3. check out this branch of `dapp-fungible-faucet`
4. within `dapp-fungible-faucet`, `agoric install`
5. `agoric start --reset`
6. In another terminal: `agoric deploy contract/deploy.js`
7. `agoric deploy api/deploy.js`
8. in another terminal: `cd ui && yarn start`
9. In another terminal: `agoric open`
10. Click the `Mint Fungible Tokens` button in the Dapp UI (http://localhost:3000/)
11. Approve the offer in your wallet. This will cause the wallet to make an offer to Zoe and invoke the offerHandler that throws.