### PR TITLE
chore: add jsconfig.json, lint

### DIFF
--- a/api/jsconfig.json
+++ b/api/jsconfig.json
@@ -1,0 +1,18 @@
+// This file can contain .js-specific Typescript compiler config.
+{
+  "compilerOptions": {
+    "target": "esnext",
+
+    "noEmit": true,
+/*
+    // The following flags are for creating .d.ts files:
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+*/
+    "downlevelIteration": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node",
+  },
+  "include": ["src/**/*.js", "test/**/*.js", "exported.js", "globals.d.ts"],
+}

--- a/contract/jsconfig.json
+++ b/contract/jsconfig.json
@@ -1,0 +1,18 @@
+// This file can contain .js-specific Typescript compiler config.
+{
+  "compilerOptions": {
+    "target": "esnext",
+
+    "noEmit": true,
+/*
+    // The following flags are for creating .d.ts files:
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+*/
+    "downlevelIteration": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node",
+  },
+  "include": ["src/**/*.js", "test/**/*.js", "exported.js", "globals.d.ts"],
+}

--- a/contract/src/contract.js
+++ b/contract/src/contract.js
@@ -1,6 +1,6 @@
 // @ts-check
 import '@agoric/zoe/exported';
-import { amountMath} from '@agoric/ertp';
+import { amountMath } from '@agoric/ertp';
 
 /**
  * This is a very simple contract that creates a new issuer and mints payments

--- a/ui/jsconfig.json
+++ b/ui/jsconfig.json
@@ -1,0 +1,18 @@
+// This file can contain .js-specific Typescript compiler config.
+{
+  "compilerOptions": {
+    "target": "esnext",
+
+    "noEmit": true,
+/*
+    // The following flags are for creating .d.ts files:
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+*/
+    "downlevelIteration": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node",
+  },
+  "include": ["src/**/*.js", "test/**/*.js", "exported.js", "globals.d.ts"],
+}


### PR DESCRIPTION
Closes https://github.com/Agoric/agoric-sdk/issues/2695

Eslint for bigints was already clean due to a previous PR, but this ensures that VSCode understands bigints as well. 