### PR TITLE
AmountMath rename, jsdoc type fix, extra await

### DIFF
--- a/contract/deploy.js
+++ b/contract/deploy.js
@@ -10,7 +10,7 @@ import { E } from '@agoric/eventual-send';
 
 /**
  * @typedef {Object} DeployPowers The special powers that agoric deploy gives us
- * @property {(path: string) => { moduleFormat: string, source: string }} bundleSource
+ * @property {(path: string) => Promise<{ moduleFormat: string, source: string }>} bundleSource
  * @property {(path: string) => string} pathResolve
  *
  * @typedef {Object} Board

--- a/contract/src/contract.js
+++ b/contract/src/contract.js
@@ -27,6 +27,7 @@ const start = async (zcf) => {
   // can be accessed synchronously.
   const { issuer, brand } = zcfMint.getIssuerRecord();
 
+  /** @type {OfferHandler} */
   const mintPayment = (seat) => {
     const amount = AmountMath.make(brand, 1000n);
     // Synchronously mint and allocate amount to seat.

--- a/contract/src/contract.js
+++ b/contract/src/contract.js
@@ -1,6 +1,6 @@
 // @ts-check
 import '@agoric/zoe/exported';
-import { amountMath } from '@agoric/ertp';
+import { AmountMath } from '@agoric/ertp';
 
 /**
  * This is a very simple contract that creates a new issuer and mints payments
@@ -28,7 +28,7 @@ const start = async (zcf) => {
   const { issuer, brand } = zcfMint.getIssuerRecord();
 
   const mintPayment = (seat) => {
-    const amount = amountMath.make(brand, 1000n);
+    const amount = AmountMath.make(brand, 1000n);
     // Synchronously mint and allocate amount to seat.
     zcfMint.mintGains({ Token: amount }, seat);
     // Exit the seat so that the user gets a payout.

--- a/contract/test/test-contract.js
+++ b/contract/test/test-contract.js
@@ -9,7 +9,7 @@ import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
 import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin';
 import { makeZoe } from '@agoric/zoe';
-import { amountMath } from '@agoric/ertp';
+import { AmountMath } from '@agoric/ertp';
 
 const contractPath = `${__dirname}/../src/contract`;
 
@@ -38,7 +38,7 @@ test('zoe - mint payments', async (t) => {
   const tokenIssuer = E(publicFacet).getTokenIssuer();
   const tokenBrand = await E(tokenIssuer).getBrand();
 
-  const tokens1000 = amountMath.make(tokenBrand, 1000n);
+  const tokens1000 = AmountMath.make(tokenBrand, 1000n);
   const tokenPayoutAmount = await E(tokenIssuer).getAmountOf(paymentP);
 
   // Bob got 1000 tokens

--- a/contract/test/test-contract.js
+++ b/contract/test/test-contract.js
@@ -20,7 +20,7 @@ test('zoe - mint payments', async (t) => {
   const bundle = await bundleSource(contractPath);
 
   // install the contract
-  const installation = await E(zoe).install(bundle);
+  const installation = E(zoe).install(bundle);
 
   const { creatorFacet, instance } = await E(zoe).startInstance(installation);
 
@@ -28,7 +28,7 @@ test('zoe - mint payments', async (t) => {
   const invitation = E(creatorFacet).makeInvitation();
 
   // Bob makes an offer using the invitation
-  const seat = await E(zoe).offer(invitation);
+  const seat = E(zoe).offer(invitation);
 
   const paymentP = E(seat).getPayout('Token');
 


### PR DESCRIPTION
While going through the faucet as part of following the [Starting a project](https://agoric.com/documentation/getting-started/start-a-project.html) guide, I noticed a few issues, fixed in this PR:

- `amountMath` is deprecated and replaced by `AmountMath`. This was renamed throughout in `agoric-sdk` but not in this repo.
- `bundleSource` is async and returns a Promise. It was `await`ed correctly but VS code was complaining about unnecessary `await`.
- `mintPayment ` wasn't typed so VS Code couldn't provide code hinting for the `seat` argument.
- A couple `await` are unnecessary in the test files:
  - `zoe.startInstance()` accepts `ERef<Installation>` (I'm hoping in the future we can automatically pipeline this usage)
  - `seat` is only used with `E()` so `await`ing would prevent pipelining.