### PR TITLE
fix: Lock material-components to v11.0.0

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -149,7 +149,7 @@
 
 
 <!-- Required Material Web JavaScript library -->
-<script src="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.js"></script>
+<script src="https://unpkg.com/material-components-web@11.0.0/dist/material-components-web.min.js"></script>
 
 <script>
 </script>


### PR DESCRIPTION
Versions v12.0.0 was throwing a number of JavaScript errors: 

<img width="1680" alt="Screen_Shot_2021-07-29_at_9 20 03_AM" src="https://user-images.githubusercontent.com/142006/127516132-bc7c8c4a-1cad-4751-b333-e2645f8f0a89.png">

After locking v11, the dapp worked as expected!