### PR TITLE
refactor: Convert RESM to NESM

### DIFF
--- a/api/deploy.js
+++ b/api/deploy.js
@@ -6,9 +6,9 @@
 
 import fs from 'fs';
 import { E } from '@agoric/eventual-send';
-import '@agoric/zoe/exported';
+import '@agoric/zoe/exported.js';
 
-import installationConstants from '../ui/public/conf/installationConstants';
+import installationConstants from '../ui/public/conf/installationConstants.js';
 
 // deploy.js runs in an ephemeral Node.js outside of swingset. The
 // spawner runs within ag-solo, so is persistent.  Once the deploy.js

--- a/api/package.json
+++ b/api/package.json
@@ -25,8 +25,9 @@
     "prettier": "^2.1.2"
   },
   "dependencies": {
-    "@agoric/zoe": "*",
-    "@agoric/eventual-send": "*"
+    "@agoric/eventual-send": "*",
+    "@agoric/marshal": "*",
+    "@agoric/zoe": "*"
   },
   "eslintConfig": {
     "extends": [

--- a/api/package.json
+++ b/api/package.json
@@ -3,9 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "description": "Agoric Dapp web server handler",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "scripts": {
     "build": "exit 0",
     "test": "exit 0",
@@ -28,8 +26,7 @@
   },
   "dependencies": {
     "@agoric/zoe": "*",
-    "@agoric/eventual-send": "*",
-    "esm": "^3.2.5"
+    "@agoric/eventual-send": "*"
   },
   "eslintConfig": {
     "extends": [

--- a/api/src/handler.js
+++ b/api/src/handler.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { E } from '@agoric/eventual-send';
-import { makeWebSocketHandler } from './lib-http';
+import { makeWebSocketHandler } from './lib-http.js';
 
 const spawnHandler = (
   { creatorFacet, board, http, invitationIssuer },

--- a/contract/deploy.js
+++ b/contract/deploy.js
@@ -63,13 +63,13 @@ export default async function deployContract(
   } = home;
 
   // We must first fund our "feePurse", the purse that we will use to
-  // pay for our interactions with Zoe. 
+  // pay for our interactions with Zoe.
   const RUNPurse = E(wallet).getPurse(pursePetnames.RUN);
   const runAmount = await E(RUNPurse).getCurrentAmount();
   const feePurse = E(faucet).getFeePurse();
-  const feePayment = await E(
-    E(wallet).getPurse(pursePetnames.RUN),
-  ).withdraw(runAmount);
+  const feePayment = await E(E(wallet).getPurse(pursePetnames.RUN)).withdraw(
+    runAmount,
+  );
   await E(feePurse).deposit(feePayment);
 
   // We must bundle up our contract code (./src/contract.js)

--- a/contract/deploy.js
+++ b/contract/deploy.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import fs from 'fs';
-import '@agoric/zoe/exported';
+import '@agoric/zoe/exported.js';
 import { E } from '@agoric/eventual-send';
 
 import { pursePetnames } from './petnames';

--- a/contract/package.json
+++ b/contract/package.json
@@ -30,6 +30,7 @@
     "@agoric/ertp": "*",
     "@agoric/eventual-send": "*",
     "@agoric/install-ses": "*",
+    "@agoric/marshal": "*",
     "@agoric/notifier": "*",
     "@agoric/store": "*",
     "@agoric/zoe": "*"

--- a/contract/package.json
+++ b/contract/package.json
@@ -3,9 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "Contract for the Agoric Dapp",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "scripts": {
     "build": "exit 0",
     "test": "ava --verbose",
@@ -34,15 +32,11 @@
     "@agoric/install-ses": "*",
     "@agoric/notifier": "*",
     "@agoric/store": "*",
-    "@agoric/zoe": "*",
-    "esm": "^3.2.5"
+    "@agoric/zoe": "*"
   },
   "ava": {
     "files": [
       "test/**/test-*.js"
-    ],
-    "require": [
-      "esm"
     ],
     "timeout": "10m"
   },

--- a/contract/src/contract.js
+++ b/contract/src/contract.js
@@ -1,5 +1,5 @@
 // @ts-check
-import '@agoric/zoe/exported';
+import '@agoric/zoe/exported.js';
 import { AmountMath } from '@agoric/ertp';
 import { Far } from '@agoric/marshal';
 

--- a/contract/test/test-contract.js
+++ b/contract/test/test-contract.js
@@ -1,17 +1,19 @@
 // @ts-check
 
-/* global __dirname */
-
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import path from 'path';
 
 import bundleSource from '@agoric/bundle-source';
 
 import { E } from '@agoric/eventual-send';
-import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin';
+import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeZoeKit } from '@agoric/zoe';
 import { AmountMath } from '@agoric/ertp';
 
-const contractPath = `${__dirname}/../src/contract`;
+const filename = new URL(import.meta.url).pathname;
+const dirname = path.dirname(filename);
+
+const contractPath = `${dirname}/../src/contract.js`;
 
 test('zoe - mint payments', async (t) => {
   const { zoeService } = makeZoeKit(makeFakeVatAdmin().admin);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "ui"
   ],
   "devDependencies": {
+    "@endo/eslint-plugin": "^0.3.10",
+    "@jessie.js/eslint-plugin": "^0.1.3",
     "eslint": "^7.23.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "useWorkspaces": true,
-  "main": "index.js",
-  "parsers": {
-    "js": "mjs"
-  },
   "workspaces": [
     "api",
     "contract",
@@ -36,9 +32,6 @@
   "dependencies": {
     "agoric": "*",
     "eslint-plugin-eslint-comments": "^3.1.2"
-  },
-  "resolutions": {
-    "**/esm": "agoric-labs/esm#Agoric-built"
   },
   "prettier": {
     "trailingComma": "all",

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,9 +5,7 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "homepage": ".",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "scripts": {
     "build": "parcel build public/index.html",
     "lint-check": "eslint '**/*.{js,jsx}'",

--- a/ui/public/conf/defaults.js
+++ b/ui/public/conf/defaults.js
@@ -1,14 +1,14 @@
 // GENERATED FROM /Users/katesills/code/dapp-fungible-faucet/api/deploy.js
 export default {
-  "INSTANCE_BOARD_ID": "794977354",
-  "INSTALLATION_BOARD_ID": "1530295560",
-  "INVITE_BRAND_BOARD_ID": "500716545",
-  "brandBoardIds": {
-    "Token": "529406044"
+  INSTANCE_BOARD_ID: '794977354',
+  INSTALLATION_BOARD_ID: '1530295560',
+  INVITE_BRAND_BOARD_ID: '500716545',
+  brandBoardIds: {
+    Token: '529406044',
   },
-  "issuerBoardIds": {
-    "Token": "715805464"
+  issuerBoardIds: {
+    Token: '715805464',
   },
-  "BRIDGE_URL": "http://127.0.0.1:8000",
-  "API_URL": "http://127.0.0.1:8000"
+  BRIDGE_URL: 'http://127.0.0.1:8000',
+  API_URL: 'http://127.0.0.1:8000',
 };

--- a/ui/public/conf/installationConstants.js
+++ b/ui/public/conf/installationConstants.js
@@ -1,5 +1,5 @@
 // GENERATED FROM /Users/katesills/code/dapp-fungible-faucet/contract/deploy.js
 export default {
-  "CONTRACT_NAME": "fungibleFaucet",
-  "INSTALLATION_BOARD_ID": "1530295560"
+  CONTRACT_NAME: 'fungibleFaucet',
+  INSTALLATION_BOARD_ID: '1530295560',
 };

--- a/ui/public/lib/api-client.js
+++ b/ui/public/lib/api-client.js
@@ -1,9 +1,9 @@
 // @ts-check
 /* globals window, WebSocket */
 
-import { registerSocket, closeSocket, getActiveSocket } from './socket';
+import { registerSocket, closeSocket, getActiveSocket } from './socket.js';
 
-import dappConstants from './constants';
+import dappConstants from './constants.js';
 
 const { API_URL } = dappConstants;
 

--- a/ui/public/lib/constants.js
+++ b/ui/public/lib/constants.js
@@ -1,5 +1,5 @@
 // Allow the runtime to override the defaults with __DAPP_CONSTANTS__
-import defaults from '../conf/defaults';
+import defaults from '../conf/defaults.js';
 
 // eslint-disable-next-line no-underscore-dangle, no-undef
 export default globalThis.__DAPP_CONSTANTS__ || defaults;

--- a/ui/public/lib/wallet-client.js
+++ b/ui/public/lib/wallet-client.js
@@ -1,7 +1,7 @@
 // @ts-check
 /* globals window document */
 
-import { registerSocket, getActiveSocket, closeSocket } from './socket';
+import { registerSocket, getActiveSocket, closeSocket } from './socket.js';
 
 // Wallet bridge
 

--- a/ui/public/src/connect.js
+++ b/ui/public/src/connect.js
@@ -1,8 +1,8 @@
 // @ts-check
 /* globals document */
-import { rpc } from '../lib/socket';
-import { activateSocket as startApi } from '../lib/api-client';
-import { activateSocket as startBridge } from '../lib/wallet-client';
+import { rpc } from '../lib/socket.js';
+import { activateSocket as startApi } from '../lib/api-client.js';
+import { activateSocket as startBridge } from '../lib/wallet-client.js';
 
 const $messages = /** @type {HTMLDivElement} */ (document.getElementById(
   `messages`,

--- a/ui/public/src/main.js
+++ b/ui/public/src/main.js
@@ -1,8 +1,8 @@
 // @ts-check
 /* globals document mdc */
-import 'regenerator-runtime/runtime';
-import dappConstants from '../lib/constants';
-import { connect } from './connect';
+import 'regenerator-runtime/runtime.js';
+import dappConstants from '../lib/constants.js';
+import { connect } from './connect.js';
 
 const {
   INVITE_BRAND_BOARD_ID,

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,6 +17,13 @@
   resolved "https://registry.yarnpkg.com/@agoric/assert/-/assert-0.0.11.tgz#6ae38173e9d7ca2be0da9b330656b48460dd0ce6"
   integrity sha512-XfWik138DBIF0Ep1t+cnRnzPrKdGjh0RjhCrRcyp7jyQ/9iEAL1zS0+8qRRqi+OaQbomhw020rvN4SoGnG4B8w==
 
+"@agoric/assert@^0.3.11":
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/@agoric/assert/-/assert-0.3.11.tgz#9047be90c3b40079f7f8e42e5ed9c3e2aa6b9f56"
+  integrity sha512-9eJnXLy49U5fFoDAkxYUvU1y4gbkA6jAnDSUpNeZQ80RPmap5A6u2lQ0S7lNxix+79O0cRkKGYdxZBduZSpujg==
+  dependencies:
+    ses "^0.14.1"
+
 "@agoric/babel-parser@^7.6.4":
   version "7.9.4"
   resolved "https://registry.yarnpkg.com/@agoric/babel-parser/-/babel-parser-7.9.4.tgz#2f9fd67f75a4a00bd1853e9d625bcc8ed479a564"
@@ -161,6 +168,11 @@
   resolved "https://registry.yarnpkg.com/@agoric/eventual-send/-/eventual-send-0.11.1.tgz#20d5a28f9ef3871caa1938f32322b5deba8166ea"
   integrity sha512-zNDvjSzt+5o7uVuU3jpjzanpn4LelWwHJvDVp1ogi/jCWFABW2Q8N7Q2Y9mh8eAk7+oq6PzaW79J/ffYCF1wYg==
 
+"@agoric/eventual-send@^0.13.27":
+  version "0.13.27"
+  resolved "https://registry.yarnpkg.com/@agoric/eventual-send/-/eventual-send-0.13.27.tgz#9b917e6663ac84783b07bc0f03bdecd2b024870d"
+  integrity sha512-6m/H1SaRJxVzEH/1vW/DAHDjjg1ZgdeEVSIx5gT54/jcyvbaZSdT75WEqTx1GAaTAyH62qLUiCmTyvZX7GA1LA==
+
 "@agoric/import-bundle@^0.0.11":
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/@agoric/import-bundle/-/import-bundle-0.0.11.tgz#edc9bb20de3202f0bfde9acc687865701f44c8a9"
@@ -200,6 +212,16 @@
   resolved "https://registry.yarnpkg.com/@agoric/make-hardener/-/make-hardener-0.1.3.tgz#807b0072bef95d935c3370d406d9dfeb719f69ee"
   integrity sha512-rc9M2ErE/Zu822OLCnAltr957ZVTsBvVZ7KA2unqDpjo3q7PqZF2hWFB1xXD2Qkfwt5exQ3BjFbkj+NUaTg4gA==
 
+"@agoric/marshal@*":
+  version "0.4.25"
+  resolved "https://registry.yarnpkg.com/@agoric/marshal/-/marshal-0.4.25.tgz#fce605f6e89f3c8dbffe94ee01a68a8adcffd0bd"
+  integrity sha512-ZkgDnqnTqGGNxExw/gtAYIbauY3mfiD1jubi69lawCQFSLIna/O1WYtPhdSK5W3OpN83z3quHgqIGF6c06akfA==
+  dependencies:
+    "@agoric/assert" "^0.3.11"
+    "@agoric/eventual-send" "^0.13.27"
+    "@agoric/nat" "^4.1.0"
+    "@agoric/promise-kit" "^0.2.25"
+
 "@agoric/marshal@^0.2.6":
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/@agoric/marshal/-/marshal-0.2.6.tgz#21f9ce36478ad97ea3ae876fd05913075c01402c"
@@ -214,6 +236,11 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@agoric/nat/-/nat-2.0.1.tgz#28aba18367deba354bdd424bdf6daa48f5e7d37f"
   integrity sha512-puvWkoaJovQib/YaSRSGJ8Kn9rogi/yyaVa3d5znSZb5WiYfUiEKW35BfexHhAdi0VfPz2anFHoRBoBSUIijNA==
+
+"@agoric/nat@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@agoric/nat/-/nat-4.1.0.tgz#102794e033ffc183a20b0f86031a2e76d204b9f6"
+  integrity sha512-2oMoh3DMn0Fx8HChPPiH8irBNdT/33ttxAZJohhd3nU3gyBRQ1u+eEoOQWfSkrE6M02iMkQM7GE9MzGmjQ6bHg==
 
 "@agoric/notifier@*", "@agoric/notifier@^0.2.2":
   version "0.2.2"
@@ -230,6 +257,13 @@
   integrity sha512-HKSmfNEY5/vqLqmwCy301IsB2BaK1vyUKq8PaTN7fHa/GhK0MHTW2+POFzxJc3JZhYWuldgefD4hTH6HSmTllg==
   dependencies:
     "@agoric/eventual-send" "^0.11.1"
+
+"@agoric/promise-kit@^0.2.25":
+  version "0.2.25"
+  resolved "https://registry.yarnpkg.com/@agoric/promise-kit/-/promise-kit-0.2.25.tgz#7fed8c8c4d004fed67b6713a3cdc626a98d9e8b0"
+  integrity sha512-B6gs2ibiji1ju5jo94lLi3DyMoRVO+xS5rWyYxLD9991QYAHS7B+udNHEHGioItdFvEXuND/aItTKmneScRq1A==
+  dependencies:
+    "@agoric/eventual-send" "^0.13.27"
 
 "@agoric/registrar@^0.1.6":
   version "0.1.6"
@@ -1294,6 +1328,13 @@
   resolved "https://registry.yarnpkg.com/@endo/base64/-/base64-0.1.0.tgz#d321d5b36f16648f0b0b05d96f93501d6a461501"
   integrity sha512-wVBsKkVV3t3mGT1XVoQAYkBpnum/OEJ0kBka3s7PSQnAne0aFmi1P9IIWyHzsoIgdai7ONTpGSgBZIk6X9dOrw==
 
+"@endo/eslint-plugin@^0.3.10":
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/@endo/eslint-plugin/-/eslint-plugin-0.3.10.tgz#e51f4ef8dae474d396b6a98a9ea9bbc983e90c57"
+  integrity sha512-zr0S9NVxY+MiHKmc5m+O5mydm2owfkp15W9JP7EQvZ4qMDlOy30qns0o7dKrk4WGloQHfMqqLdOkCYeKUGKSAQ==
+  dependencies:
+    requireindex "~1.1.0"
+
 "@eslint/eslintrc@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"
@@ -1313,6 +1354,13 @@
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
   integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
+
+"@jessie.js/eslint-plugin@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@jessie.js/eslint-plugin/-/eslint-plugin-0.1.3.tgz#4df87d639dbc8ffb4c0b0168de1311b7f522cc75"
+  integrity sha512-wyx/Wz/5gx87GRijQ3U6XGBYh9AnJdkw5pNgz0xZrLv6a6+l/t1p/7AeqYeolu5nDPuic/jSxfybkcWgYaP7UA==
+  dependencies:
+    requireindex "~1.1.0"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -3718,7 +3766,7 @@ eslint@^7.23.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-esm@^3.2.25, esm@^3.2.5, esm@agoric-labs/esm#Agoric-built:
+esm@^3.2.25, esm@^3.2.5:
   version "3.2.25"
   resolved "https://codeload.github.com/agoric-labs/esm/tar.gz/3603726ad4636b2f865f463188fcaade6375638e"
 
@@ -7277,6 +7325,11 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
+  integrity sha1-5UBLgVV+91225JxacgBIk/4D4WI=
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -7551,6 +7604,11 @@ ses@^0.12.6:
     "@agoric/babel-standalone" "^7.9.5"
     "@agoric/make-hardener" "^0.1.2"
     "@agoric/transform-module" "^0.4.1"
+
+ses@^0.14.1:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/ses/-/ses-0.14.2.tgz#3dd62c1779cc9ee5df506d7b1a40fe514ba541e1"
+  integrity sha512-RKAOt8KxkJJyclwfd0mQ6GtmIyYUOrDew7DwKM6DTWY8f9u1eDJccpHXvxDhpXDcWlJ40dtC/FCx12BFZuGPng==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This change is predicated on https://github.com/Agoric/agoric-sdk/pull/3686 and will break any deployment of `agoric-cli` until it update to a release with the fix.

This change is submited for review of the `nesm` branch and not recommended to land until telemetry (what telemetry!?) indicates clients have generally upgraded.

Until then, it will be possible to create new dapps with Node.js ESM with the command `agoric init --dapp-branch nesm`.