### PR TITLE
refactor: Reconvert RESM to NESM

### DIFF
--- a/api/deploy.js
+++ b/api/deploy.js
@@ -6,9 +6,9 @@
 
 import fs from 'fs';
 import { E } from '@agoric/eventual-send';
-import '@agoric/zoe/exported';
+import '@agoric/zoe/exported.js';
 
-import installationConstants from '../ui/public/conf/installationConstants';
+import installationConstants from '../ui/public/conf/installationConstants.js';
 
 // deploy.js runs in an ephemeral Node.js outside of swingset. The
 // spawner runs within ag-solo, so is persistent.  Once the deploy.js

--- a/api/package.json
+++ b/api/package.json
@@ -3,9 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "description": "Agoric Dapp web server handler",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "scripts": {
     "build": "exit 0",
     "test": "exit 0",
@@ -29,8 +27,7 @@
   "dependencies": {
     "@agoric/eventual-send": "*",
     "@agoric/marshal": "*",
-    "@agoric/zoe": "*",
-    "esm": "^3.2.5"
+    "@agoric/zoe": "*"
   },
   "eslintConfig": {
     "extends": [

--- a/api/src/handler.js
+++ b/api/src/handler.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { E } from '@agoric/eventual-send';
-import { makeWebSocketHandler } from './lib-http';
+import { makeWebSocketHandler } from './lib-http.js';
 
 const spawnHandler = (
   { creatorFacet, board, http, invitationIssuer },

--- a/contract/deploy.js
+++ b/contract/deploy.js
@@ -1,10 +1,10 @@
 // @ts-check
 
 import fs from 'fs';
-import '@agoric/zoe/exported';
+import '@agoric/zoe/exported.js';
 import { E } from '@agoric/eventual-send';
 
-import { pursePetnames } from './petnames';
+import { pursePetnames } from './petnames.js';
 
 // This script takes our contract code, installs it on Zoe, and makes
 // the installation publicly available. Our backend API script will

--- a/contract/package.json
+++ b/contract/package.json
@@ -3,9 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "Contract for the Agoric Dapp",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "scripts": {
     "build": "exit 0",
     "test": "ava --verbose",
@@ -35,15 +33,11 @@
     "@agoric/marshal": "*",
     "@agoric/notifier": "*",
     "@agoric/store": "*",
-    "@agoric/zoe": "*",
-    "esm": "^3.2.5"
+    "@agoric/zoe": "*"
   },
   "ava": {
     "files": [
       "test/**/test-*.js"
-    ],
-    "require": [
-      "esm"
     ],
     "timeout": "10m"
   },

--- a/contract/src/contract.js
+++ b/contract/src/contract.js
@@ -1,5 +1,5 @@
 // @ts-check
-import '@agoric/zoe/exported';
+import '@agoric/zoe/exported.js';
 import { AmountMath } from '@agoric/ertp';
 import { Far } from '@agoric/marshal';
 

--- a/contract/test/test-contract.js
+++ b/contract/test/test-contract.js
@@ -1,17 +1,19 @@
 // @ts-check
 
-/* global __dirname */
-
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import path from 'path';
 
 import bundleSource from '@agoric/bundle-source';
 
 import { E } from '@agoric/eventual-send';
-import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin';
+import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeZoeKit } from '@agoric/zoe';
 import { AmountMath } from '@agoric/ertp';
 
-const contractPath = `${__dirname}/../src/contract`;
+const filename = new URL(import.meta.url).pathname;
+const dirname = path.dirname(filename);
+
+const contractPath = `${dirname}/../src/contract.js`;
 
 test('zoe - mint payments', async (t) => {
   const { zoeService } = makeZoeKit(makeFakeVatAdmin().admin);

--- a/package.json
+++ b/package.json
@@ -3,10 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "useWorkspaces": true,
-  "main": "index.js",
-  "parsers": {
-    "js": "mjs"
-  },
   "workspaces": [
     "api",
     "contract",
@@ -38,9 +34,6 @@
   "dependencies": {
     "agoric": "*",
     "eslint-plugin-eslint-comments": "^3.1.2"
-  },
-  "resolutions": {
-    "**/esm": "agoric-labs/esm#Agoric-built"
   },
   "prettier": {
     "trailingComma": "all",

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,9 +5,7 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "homepage": ".",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "scripts": {
     "build": "parcel build public/index.html",
     "lint-check": "eslint '**/*.{js,jsx}'",

--- a/ui/package.json
+++ b/ui/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "agoric": "*",
+    "caniuse-lite": "1.0.30001251",
     "eslint": "^7.23.0",
     "eslint-config-airbnb": "^18.2.0",
     "eslint-config-prettier": "^6.12.0",

--- a/ui/public/lib/api-client.js
+++ b/ui/public/lib/api-client.js
@@ -1,9 +1,9 @@
 // @ts-check
 /* globals window, WebSocket */
 
-import { registerSocket, closeSocket, getActiveSocket } from './socket';
+import { registerSocket, closeSocket, getActiveSocket } from './socket.js';
 
-import dappConstants from './constants';
+import dappConstants from './constants.js';
 
 const { API_URL } = dappConstants;
 

--- a/ui/public/lib/constants.js
+++ b/ui/public/lib/constants.js
@@ -1,5 +1,5 @@
 // Allow the runtime to override the defaults with __DAPP_CONSTANTS__
-import defaults from '../conf/defaults';
+import defaults from '../conf/defaults.js';
 
 // eslint-disable-next-line no-underscore-dangle, no-undef
 export default globalThis.__DAPP_CONSTANTS__ || defaults;

--- a/ui/public/lib/wallet-client.js
+++ b/ui/public/lib/wallet-client.js
@@ -1,7 +1,7 @@
 // @ts-check
 /* globals window document */
 
-import { registerSocket, getActiveSocket, closeSocket } from './socket';
+import { registerSocket, getActiveSocket, closeSocket } from './socket.js';
 
 // Wallet bridge
 

--- a/ui/public/src/connect.js
+++ b/ui/public/src/connect.js
@@ -1,8 +1,8 @@
 // @ts-check
 /* globals document */
-import { rpc } from '../lib/socket';
-import { activateSocket as startApi } from '../lib/api-client';
-import { activateSocket as startBridge } from '../lib/wallet-client';
+import { rpc } from '../lib/socket.js';
+import { activateSocket as startApi } from '../lib/api-client.js';
+import { activateSocket as startBridge } from '../lib/wallet-client.js';
 
 const $messages = /** @type {HTMLDivElement} */ (document.getElementById(
   `messages`,

--- a/ui/public/src/main.js
+++ b/ui/public/src/main.js
@@ -1,8 +1,8 @@
 // @ts-check
 /* globals document mdc */
-import 'regenerator-runtime/runtime';
-import dappConstants from '../lib/constants';
-import { connect } from './connect';
+import 'regenerator-runtime/runtime.js';
+import dappConstants from '../lib/constants.js';
+import { connect } from './connect.js';
 
 const {
   INVITE_BRAND_BOARD_ID,

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1457,9 +1457,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001035:
-  version "1.0.30001038"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001038.tgz#44da3cbca2ab6cb6aa83d1be5d324e17f141caff"
-  integrity sha512-zii9quPo96XfOiRD4TrfYGs+QsGZpb2cGiMAzPjtf/hpFgB6zCPZgJb7I1+EATeMw/o+lG8FyRAnI+CWStHcaQ==
+  version "1.0.30001251"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz"
+  integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
 
 caseless@~0.12.0:
   version "0.12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3771,7 +3771,7 @@ eslint@^7.23.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-esm@^3.2.25, esm@^3.2.5, esm@agoric-labs/esm#Agoric-built:
+esm@^3.2.25, esm@^3.2.5:
   version "3.2.25"
   resolved "https://codeload.github.com/agoric-labs/esm/tar.gz/3603726ad4636b2f865f463188fcaade6375638e"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2367,6 +2367,11 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
+caniuse-lite@1.0.30001251:
+  version "1.0.30001251"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz#6853a606ec50893115db660f82c094d18f096d85"
+  integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
+
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001135:
   version "1.0.30001148"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz#dc97c7ed918ab33bf8706ddd5e387287e015d637"


### PR DESCRIPTION
This time with feeling. Evidently, the failure last time was due to the omission of a single `.js` extension.

- [x] pass in integration with agoric-sdk https://github.com/Agoric/agoric-sdk/pull/3750