### PR TITLE
fix(ui): start using SES

### DIFF
--- a/_agstate/.gitignore
+++ b/_agstate/.gitignore
@@ -1,2 +1,3 @@
 agoric-wallet
 keys
+agoric-servers

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,9 +15,9 @@
   },
   "browserslist": {
     "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
     ],
     "development": [
       "last 1 chrome version",
@@ -61,7 +61,8 @@
     "eslint-plugin-react": "^7.21.4",
     "eslint-plugin-react-hooks": "^4.1.2",
     "prettier": "^2.1.2",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "ses": "^0.14.2"
   },
   "prettier": {
     "trailingComma": "all",

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -149,11 +149,8 @@
 
 
 <!-- Required Material Web JavaScript library -->
-<script src="https://unpkg.com/material-components-web@11.0.0/dist/material-components-web.min.js"></script>
+<script src="https://unpkg.com/material-components-web@^11.0.0/dist/material-components-web.min.js"></script>
 
-<script>
-</script>
-
-    <script type="module" src="src/main.js"></script>
+<script type="module" src="src/main.js"></script>
   </body>
 </html>

--- a/ui/public/src/install-ses-lockdown.js
+++ b/ui/public/src/install-ses-lockdown.js
@@ -1,0 +1,14 @@
+/* global lockdown */
+import 'ses/dist/ses.umd'; // adds lockdown, harden, and Compartment
+import '@agoric/eventual-send/shim'; // adds support needed by E
+
+// Help lock down the JS environment.  The start compartment (current evaluation context)
+// can still access powerful globals, but this start compartment can use `new Compartment(...)`
+// to evaluate code with stricter confinement.
+lockdown({
+  __allowUnsafeMonkeyPatching__: true,
+  errorTaming: 'unsafe',
+  overrideTaming: 'severe',
+});
+
+Error.stackTraceLimit = Infinity;

--- a/ui/public/src/install-ses-lockdown.js
+++ b/ui/public/src/install-ses-lockdown.js
@@ -6,7 +6,6 @@ import '@agoric/eventual-send/shim'; // adds support needed by E
 // can still access powerful globals, but this start compartment can use `new Compartment(...)`
 // to evaluate code with stricter confinement.
 lockdown({
-  __allowUnsafeMonkeyPatching__: true,
   errorTaming: 'unsafe',
   overrideTaming: 'severe',
 });

--- a/ui/public/src/install-ses-lockdown.js
+++ b/ui/public/src/install-ses-lockdown.js
@@ -1,4 +1,4 @@
-/* global lockdown */
+/* eslint-disable import/no-extraneous-dependencies */
 import 'ses/dist/ses.umd'; // adds lockdown, harden, and Compartment
 import '@agoric/eventual-send/shim'; // adds support needed by E
 

--- a/ui/public/src/main.js
+++ b/ui/public/src/main.js
@@ -1,6 +1,6 @@
 // @ts-check
 /* globals document mdc */
-import 'regenerator-runtime/runtime.js';
+import './install-ses-lockdown.js';
 import dappConstants from '../lib/constants.js';
 import { connect } from './connect.js';
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1457,9 +1457,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001035:
-  version "1.0.30001251"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz"
-  integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
+  version "1.0.30001252"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz"
+  integrity sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==
 
 caseless@~0.12.0:
   version "0.12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7610,7 +7610,7 @@ ses@^0.12.6:
     "@agoric/make-hardener" "^0.1.2"
     "@agoric/transform-module" "^0.4.1"
 
-ses@^0.14.1:
+ses@^0.14.1, ses@^0.14.2:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/ses/-/ses-0.14.2.tgz#3dd62c1779cc9ee5df506d7b1a40fe514ba541e1"
   integrity sha512-RKAOt8KxkJJyclwfd0mQ6GtmIyYUOrDew7DwKM6DTWY8f9u1eDJccpHXvxDhpXDcWlJ40dtC/FCx12BFZuGPng==


### PR DESCRIPTION
Closes endojs/endo#875

These are fixes I needed to use SES on the UI side.

By preparing this, it should now be possible to start migrating to eventual-send instead of a JSON-RPC-like connection.
