### PR TITLE
feat: Use deploy script helpers

### DIFF
--- a/contract/deploy.js
+++ b/contract/deploy.js
@@ -1,9 +1,8 @@
 // @ts-check
 
-import fs from 'fs';
+import * as fs from 'fs/promises';
 import '@agoric/zoe/exported.js';
-import { E } from '@endo/eventual-send';
-import bundleSource from '@endo/bundle-source';
+import { makeHelpers } from '@agoric/deploy-script-support';
 
 // This script takes our contract code, installs it on Zoe, and makes
 // the installation publicly available. Our backend API script will
@@ -17,78 +16,32 @@ import bundleSource from '@endo/bundle-source';
 /**
  * @typedef {object} DeployPowers The special powers that agoric deploy gives us
  * @property {(path: string) => string} pathResolve
+ * @property {(bundle: unknown) => any} publishBundle
  * @typedef {object} Board
- * @property {(id: string) => any} getValue
- * @property {(value: any) => string} getId
- * @property {(value: any) => boolean} has
+ * @property {(id: string) => unknown} getValue
+ * @property {(value: unknown) => string} getId
+ * @property {(value: unknown) => boolean} has
  * @property {() => [string]} ids
  */
 
 /**
- * @param {(path: string) => string} pathResolve
- * @param {ERef<ZoeService>} zoe
- * @param {ERef<Board>} board
- * @returns {Promise<{ CONTRACT_NAME: string, INSTALLATION_BOARD_ID: string }>}
- */
-const installBundle = async (pathResolve, zoe, board) => {
-  // We must bundle up our contract code (./src/contract.js)
-  // and install it on Zoe. This returns an installationHandle, an
-  // opaque, unforgeable identifier for our contract code that we can
-  // reuse again and again to create new, live contract instances.
-  const bundle = await bundleSource(pathResolve(`./src/contract.js`));
-  const installation = await E(zoe).install(bundle);
-
-  // Let's share this installation with other people, so that
-  // they can run our contract code by making a contract
-  // instance (see the api deploy script in this repo to see an
-  // example of how to use the installation to make a new contract
-  // instance.)
-  // To share the installation, we're going to put it in the
-  // board. The board is a shared, on-chain object that maps
-  // strings to objects.
-  const CONTRACT_NAME = 'fungibleFaucet';
-  const INSTALLATION_BOARD_ID = await E(board).getId(installation);
-  console.log('- SUCCESS! contract code installed on Zoe');
-  console.log(`-- Contract Name: ${CONTRACT_NAME}`);
-  console.log(`-- Installation Board Id: ${INSTALLATION_BOARD_ID}`);
-  return { CONTRACT_NAME, INSTALLATION_BOARD_ID };
-};
-
-/**
  * @param {Promise<{zoe: ERef<ZoeService>, board: ERef<Board>, agoricNames:
  * object, wallet: ERef<object>, faucet: ERef<object>}>} homePromise
- * @param {DeployPowers} powers
+ * @param {DeployPowers} endowments
  */
-const deployContract = async (homePromise, { pathResolve }) => {
+const deployContract = async (homePromise, endowments) => {
   // Your off-chain machine (what we call an ag-solo) starts off with
   // a number of references, some of which are shared objects on chain, and
   // some of which are objects that only exist on your machine.
 
-  // Let's wait for the promise to resolve.
-  const home = await homePromise;
+  const { pathResolve } = endowments;
 
-  // Unpack the references.
-  const {
-    // *** ON-CHAIN REFERENCES ***
+  const { install } = await makeHelpers(homePromise, endowments);
 
-    // Zoe lives on-chain and is shared by everyone who has access to
-    // the chain. In this demo, that's just you, but on our testnet,
-    // everyone has access to the same Zoe.
-    zoe,
-
-    // The board is an on-chain object that is used to make private
-    // on-chain objects public to everyone else on-chain. These
-    // objects get assigned a unique string id. Given the id, other
-    // people can access the object through the board. Ids and values
-    // have a one-to-one bidirectional mapping. If a value is added a
-    // second time, the original id is just returned.
-    board,
-  } = home;
-
-  const { CONTRACT_NAME, INSTALLATION_BOARD_ID } = await installBundle(
-    pathResolve,
-    zoe,
-    board,
+  const CONTRACT_NAME = 'fungibleFaucet';
+  const { id: INSTALLATION_BOARD_ID } = await install(
+    './src/contract.js',
+    CONTRACT_NAME,
   );
 
   // Save the constants somewhere where the UI and api can find it.
@@ -105,8 +58,8 @@ const deployContract = async (homePromise, { pathResolve }) => {
 // GENERATED FROM ${pathResolve('./deploy.js')}
 export default ${JSON.stringify(dappConstants, undefined, 2)};
 `;
-  await fs.promises.mkdir(defaultsFolder, { recursive: true });
-  await fs.promises.writeFile(defaultsFile, defaultsContents);
+  await fs.mkdir(defaultsFolder, { recursive: true });
+  await fs.writeFile(defaultsFile, defaultsContents);
 };
 
 export default deployContract;

--- a/contract/package.json
+++ b/contract/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@endo/bundle-source": "^2.1.1",
     "@agoric/assert": "beta",
+    "@agoric/deploy-script-support": "beta",
     "@agoric/ertp": "beta",
     "@endo/eventual-send": "^0.14.8",
     "@endo/init": "^0.5.37",

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,7 +58,7 @@
   dependencies:
     bindings "^1.2.1"
 
-"@agoric/deploy-script-support@^0.9.0":
+"@agoric/deploy-script-support@^0.9.0", "@agoric/deploy-script-support@beta":
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/@agoric/deploy-script-support/-/deploy-script-support-0.9.0.tgz#491e4e141f099188d936d23b26c560a3c434c3ee"
   integrity sha512-n6lWx73uJcNBtPgEgASgS24MfCa4zX0ADRN8gDGgkCnPzM0sb2PO34GK0DHTDLTRrZp727bK861ltJks1voicA==
@@ -2117,7 +2117,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
+braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -3415,7 +3415,7 @@ github-from-package@0.0.0:
   resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
   integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
 
-glob-parent@^5.1.0, glob-parent@^5.1.2, glob-parent@~5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -4231,7 +4231,7 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
 
-micromatch@^4.0.2, micromatch@^4.0.4:
+micromatch@^4.0.4:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
@@ -4852,7 +4852,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==


### PR DESCRIPTION
This change refactors the fungible faucet dapp's deploy script to use Agoric SDK's deploy script helpers.
This is a prelude to altering the deploy script helper to publish bundles directly to the chain.

- feat: Use deploy-script-helpers for installation
- chore: Update yarn.lock
