### PR TITLE
fix: removed feePurse from test

### DIFF
--- a/contract/test/test-contract.js
+++ b/contract/test/test-contract.js
@@ -17,10 +17,7 @@ const dirname = path.dirname(filename);
 const contractPath = `${dirname}/../src/contract.js`;
 
 test('zoe - mint payments', async (t) => {
-  const { zoeService } = makeZoeKit(makeFakeVatAdmin().admin);
-  const feePurse = E(zoeService).makeFeePurse();
-  const zoe = E(zoeService).bindDefaultFeePurse(feePurse);
-
+  const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin().admin);
   // pack the contract
   const bundle = await bundleSource(contractPath);
 


### PR DESCRIPTION
`agoric init` currently scaffolds out a project with broken tests. this is a result of [#5997](https://github.com/Agoric/agoric-sdk/pull/5997) during which support for `makeFeePurse` and `bindDefaultFeePurse` has been dropped.


### `test-contract.js` - current (broken)
```js
  const feePurse = E(zoeService).makeFeePurse();
  const zoe = E(zoeService).bindDefaultFeePurse(feePurse);
```

### `test-contract.js` - proposed in this PR

```js
  const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin().admin);
```

if this is approved, then the same change is needed in a [handful of other example repositories](https://github.com/search?q=org%3AAgoric+bindDefaultFeePurse&type=code)